### PR TITLE
Remove ops-agent from packageupgrade test

### DIFF
--- a/test_suites/packageupgrade/packageupgrade_test.go
+++ b/test_suites/packageupgrade/packageupgrade_test.go
@@ -103,8 +103,6 @@ func TestPackageUpgrade(t *testing.T) {
 	packages := []string{
 		"certgen",
 		"googet",
-		//Ops Agent uses its own repo; need to make a separate change to test it
-		//"google-cloud-ops-agent",
 		"google-compute-engine-diagnostics",
 		"google-compute-engine-metadata-scripts",
 		"google-compute-engine-powershell",


### PR DESCRIPTION
We dont need to test this and it uses its own repo; removing it