### PR TITLE
Don't include openssh in the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ ENV GO111MODULE on
 RUN ./local_build.sh -o /out
 
 FROM alpine:latest
-RUN apk add --no-cache openssh-keygen
 RUN apk update && apk upgrade
 COPY --from=builder /out/* /
 


### PR DESCRIPTION
The docker image is not being used for ssh, while openssh could have vulnerabilities. It does not need to be in the docker file.