### PR TITLE
Skip Windows KMS in staging

### DIFF
--- a/test_suites/vmspec/setup.go
+++ b/test_suites/vmspec/setup.go
@@ -63,7 +63,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		return fmt.Errorf("failed to get zone: %v", err)
 	}
 	sourceInst := &daisy.Instance{}
-	disks := []*compute.Disk{&compute.Disk{Name: "source", Type: imagetest.PdBalanced, Zone: zone.Name}}
+	disks := []*compute.Disk{{Name: "source", Type: imagetest.PdBalanced, Zone: zone.Name}}
 	source, err := t.CreateTestVMMultipleDisks(disks, sourceInst)
 	if err != nil {
 		return err

--- a/testworkflow_test.go
+++ b/testworkflow_test.go
@@ -46,7 +46,7 @@ func TestAddNewVMStep(t *testing.T) {
 	if twf.wf == nil {
 		t.Fatal("test workflow is malformed")
 	}
-	step, _, err := twf.addNewVMStep([]*compute.Disk{&compute.Disk{Name: "test"}}, &daisy.Instance{})
+	step, _, err := twf.addNewVMStep([]*compute.Disk{{Name: "test"}}, &daisy.Instance{})
 	if err != nil {
 		t.Errorf("failed to add new VM step to test workflow: %v", err)
 	}


### PR DESCRIPTION
Skip Windows KMS on staging. Before this change, the VM on any window-2019 image would fail in the test grid for the staging environment with a timeout, and the final message shown would be for KMS errors.

Sample local test:


./manager -project bct-staging-windows-infra -zone us-central1-staginga -compute_endpoint_override=https://www.googleapis.com/compute/staging_v1/ -images projects/gce-staging-images/global/images/family/windows-2019 -filter hostnamevalidation -local_path .
2024/10/07 18:52:49 Running in project bct-staging-windows-infra zone us-central1-staginga. Tests will run in projects: [bct-staging-windows-infra]
2024/10/07 18:52:49 using -filter hostnamevalidation
2024/10/07 18:52:49 Using compute endpoint "https://www.googleapis.com/compute/staging_v1/"
2024/10/07 18:52:49 Add test workflow for test hostnamevalidation on image projects/gce-staging-images/global/images/family/windows-2019
2024/10/07 18:52:50 Done with setup
2024/10/07 18:52:51 Storing artifacts and logs in gs://bct-staging-windows-infra-cloud-test-outputs/2024-10-07T18:52:51Z
2024/10/07 18:52:51 running test hostnamevalidation/windows-server-2019-dc-v20240913 (ID 9s3p4) in project bct-staging-windows-infra, progress: total: 1, running: 1, finished: 0, delta: 1
2024/10/07 18:58:37 finished test hostnamevalidation/windows-server-2019-dc-v20240913 (ID 9s3p4) in project bct-staging-windows-infra, time spent: 05m 46s
2024/10/07 18:58:37 cleaning up after test hostnamevalidation/windows-server-2019-dc-v20240913 (ID 9s3p4) in project bct-staging-windows-infra, progress: total: 1, running: 0, finished: 1, delta: 0
<?xml version="1.0" encoding="UTF-8"?>
<testsuites time="2.830" tests="5" skipped="4">
	<testsuite name="hostnamevalidation-windows-2019" tests="5" failures="0" errors="0" id="0" skipped="4" time="2.830">
		<properties>
			<property name="image_family" value="windows-2019"></property>
			<property name="image" value="https://www.googleapis.com/compute/staging_v1/projects/gce-staging-images/global/images/windows-server-2019-dc-v20240913"></property>
			<property name="project" value="bct-staging-windows-infra"></property>
		</properties>
		<testcase name="TestHostname" classname="" time="2.830"></testcase>
		<testcase name="TestFQDN" classname="" time="0.000">
			<skipped message="Skipped"><![CDATA[    test_utils.go:414: Test only run on linux.]]></skipped>
		</testcase>
		<testcase name="TestHostKeysGeneratedOnce" classname="" time="0.000">
			<skipped message="Skipped"><![CDATA[    test_utils.go:414: Test only run on linux.]]></skipped>
		</testcase>
		<testcase name="TestHostsFile" classname="" time="0.000">
			<skipped message="Skipped"><![CDATA[    test_utils.go:414: Test only run on linux.]]></skipped>
		</testcase>
		<testcase name="TestCustomHostname" classname="hostnamevalidation-windows-2019">
			<skipped message=""><![CDATA[TestCustomHostname disabled on projects/gce-staging-images/global/images/family/windows-2019]]></skipped>
		</testcase>
	</testsuite>
</testsuites>
