### PR TITLE
feat: Add new regexp filter for specific tests within suites (-exclude_discrete_tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Testing components are built into a container image. The entrypoint is
     	skip tests matching filter
     -filter string
     	only run tests matching filter
+    -exclude_discrete_tests string
+        skip individual tests within the suite that match the filter
     -gcs_path string
     	GCS Path for Daisy working directory
     -images string

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -83,8 +83,9 @@ var (
 	computeEndpointOverride = flag.String("compute_endpoint_override", "", "compute client endpoint override")
 	parallelCount           = flag.Int("parallel_count", 5, "TestParallelCount")
 	parallelStagger         = flag.String("parallel_stagger", "60s", "parseable time.Duration to stagger each parallel test")
-	filter                  = flag.String("filter", "", "only run tests matching filter")
-	exclude                 = flag.String("exclude", "", "skip tests matching filter")
+	filter                  = flag.String("filter", "", "only run test suites matching filter")
+	exclude                 = flag.String("exclude", "", "skip test suites matching filter")
+	testExcludeFilter       = flag.String("exclude_discrete_tests", "", "skip individual tests within suites that match the regexp filter")
 	machineType             = flag.String("machine_type", "", "deprecated, use -x86_shape and/or -arm64_shape instead")
 	x86Shape                = flag.String("x86_shape", "n1-standard-1", "default x86(-32 and -64) vm shape for tests not requiring a specific shape")
 	arm64Shape              = flag.String("arm64_shape", "t2a-standard-1", "default arm64 vm shape for tests not requiring a specific shape")
@@ -157,6 +158,10 @@ func main() {
 			log.Fatal("-exclude flag not valid:", err)
 		}
 		log.Printf("using -exclude %s", *exclude)
+	}
+
+	if *testExcludeFilter != "" {
+		log.Printf("Using -exclude_discrete_tests %s", *testExcludeFilter)
 	}
 
 	if *machineType != "" {
@@ -353,7 +358,7 @@ func main() {
 			}
 
 			log.Printf("Add test workflow for test %s on image %s", testPackage.name, image)
-			test, err := imagetest.NewTestWorkflow(computeclient, *computeEndpointOverride, testPackage.name, image, *timeout, *project, *zone, *x86Shape, *arm64Shape)
+			test, err := imagetest.NewTestWorkflow(computeclient, *computeEndpointOverride, testPackage.name, image, *timeout, *project, *zone, *testExcludeFilter, *x86Shape, *arm64Shape)
 			if err != nil {
 				log.Fatalf("Failed to create test workflow: %v", err)
 			}

--- a/cmd/wrapper/main.go
+++ b/cmd/wrapper/main.go
@@ -114,6 +114,11 @@ func main() {
 		testArguments = append(testArguments, "-test.run", testRun)
 	}
 
+	testExcludeFilter, err := utils.GetMetadata(ctx, "instance", "attributes", "_exclude_discrete_tests")
+	if err == nil && testExcludeFilter != "" {
+		testArguments = append(testArguments, "-test.skip", testExcludeFilter)
+	}
+
 	testPackage, err := utils.GetMetadata(ctx, "instance", "attributes", "_test_package_name")
 	if err != nil {
 		log.Fatalf("failed to get metadata _test_package_name: %v", err)

--- a/testworkflow_test.go
+++ b/testworkflow_test.go
@@ -533,6 +533,7 @@ func TestNewTestWorkflow(t *testing.T) {
 		arm64Shape          string
 		timeout             string
 		expectedMachineType string
+		testExcludeFilter   string
 	}{
 		{
 			name:                "arm",
@@ -545,6 +546,7 @@ func TestNewTestWorkflow(t *testing.T) {
 			arm64Shape:          "t2a-standard-1",
 			timeout:             "30m",
 			expectedMachineType: "t2a-standard-1",
+			testExcludeFilter:   "",
 		},
 		{
 			name:                "x86",
@@ -557,6 +559,7 @@ func TestNewTestWorkflow(t *testing.T) {
 			arm64Shape:          "t2a-standard-1",
 			timeout:             "20m",
 			expectedMachineType: "n1-standard-1",
+			testExcludeFilter:   "",
 		},
 		{
 			name:                "unspecified arch",
@@ -569,6 +572,7 @@ func TestNewTestWorkflow(t *testing.T) {
 			arm64Shape:          "t2a-standard-1",
 			timeout:             "20m",
 			expectedMachineType: "n1-standard-1",
+			testExcludeFilter:   "TestSSH",
 		},
 	}
 	for _, tc := range testcases {
@@ -593,7 +597,7 @@ func TestNewTestWorkflow(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer srv.Close()
-			twf, err := NewTestWorkflow(client, "", tc.name, tc.image, tc.timeout, tc.project, tc.zone, tc.x86Shape, tc.arm64Shape)
+			twf, err := NewTestWorkflow(client, "", tc.name, tc.image, tc.timeout, tc.project, tc.zone, tc.testExcludeFilter, tc.x86Shape, tc.arm64Shape)
 			if err != nil {
 				t.Fatalf("failed to create test workflow: %v", err)
 			}


### PR DESCRIPTION
Add the ability to skip/not parse the results of any individual tests within the different suites. Uses regexp and flag.Lookup.