### PR TITLE
fix: licensevalidation suite for Ubuntu Minimal Pro images

### DIFF
--- a/test_suites/licensevalidation/setup.go
+++ b/test_suites/licensevalidation/setup.go
@@ -190,7 +190,7 @@ func requiredLicenseList(t *imagetest.TestWorkflow) ([]string, error) {
 				fmt.Sprintf(licenseURLTmpl, "ubuntu-os-accelerator-images", fmt.Sprintf("nvidia-%s", gpuDriverVersion)),
 			)
 		}
-	case strings.Contains(image.Name, "ubuntu-pro"):
+	case strings.Contains(image.Name, "ubuntu-pro") || strings.Contains(image.Name, "ubuntu-minimal-pro"):
 		project = "ubuntu-os-pro-cloud"
 	case strings.Contains(image.Name, "ubuntu"):
 		project = "ubuntu-os-cloud"


### PR DESCRIPTION
Ubuntu Minimal Pro images are also licensed under `ubuntu-os-pro-cloud`, this catch is missing from the `licensevalidation` suite.
Tested on a Ubuntu Minimal Pro daily image.