### PR TITLE
Add proper name vs. alternative name for `570` drivers

### DIFF
--- a/test_suites/packagevalidation/package_test.go
+++ b/test_suites/packagevalidation/package_test.go
@@ -239,8 +239,9 @@ func TestGuestPackages(t *testing.T) {
 			images:       []*regexp.Regexp{regexp.MustCompile("ubuntu.*nvidia-550")},
 		},
 		{
-			name:   "nvidia-dc-driver570-cuda",
-			images: []*regexp.Regexp{regexp.MustCompile("ubuntu.*nvidia-570")},
+			name:         "linux-modules-nvidia-570-server-open-gcp",
+			alternatives: []string{"nvidia-dc-driver570-cuda"},
+			images:       []*regexp.Regexp{regexp.MustCompile("ubuntu.*nvidia-570")},
 		},
 		{
 			name:         "nvidia-kernel-common",


### PR DESCRIPTION
The installed name on Ubuntu distros is `linux-modules-nvidia-570-server-open-gcp` as opposed to `nvidia-dc-driver570-cuda`, leading to a false failure.

Before this commit:
````
<testcase name="TestGuestPackages" classname="" time="0.080">
    <failure message="Failed"><![CDATA[    package_test.go:306: package nvidia-dc-driver570-cuda has wrong installation state, got (shouldNotBeInstalled: false, packageInstalled: false)]]>
    </failure>
</testcase>
````

With this commit:
````
<testcase name="TestGuestPackages" classname="" time="0.080"></testcase>
````