### PR TITLE
Ensure package validation works on Rocky NVIDIA 580 driver

### DIFF
--- a/test_suites/packagevalidation/package_test.go
+++ b/test_suites/packagevalidation/package_test.go
@@ -257,13 +257,13 @@ func TestGuestPackages(t *testing.T) {
 			images:       []*regexp.Regexp{regexp.MustCompile("ubuntu.*nvidia-latest")},
 		},
 		{
-			name:         "mlnx-ofed-guest",
-			alternatives: []string{"doca-ofed"},
+			name:         "doca-ofed",
+			alternatives: []string{"mlnx-ofed-guest"},
 			images:       []*regexp.Regexp{regexp.MustCompile("rocky.*nvidia")},
 		},
 		{
-			name:         "nvidia-open-gpu-kernel-modules",
-			alternatives: []string{"kmod-nvidia-open-latest", "kmod-nvidia-dc-open-latest", "kmod-nvidia-dc-open550", "kmod-nvidia-dc-open570"},
+			name:         "kmod-nvidia-dc-open-latest",
+			alternatives: []string{"kmod-nvidia-dc-open570", "kmod-nvidia-dc-open580"},
 			images:       []*regexp.Regexp{regexp.MustCompile("rocky.*nvidia")},
 		},
 	}


### PR DESCRIPTION
* `doca-ofed` is the default package name, so swap that
* Remove unused packages for the NVIDIA kmod and add kmod-nvidia-dc-open580