### PR TITLE
Don't error if header values contain google.com

### DIFF
--- a/test_suites/metadata/metadata_test.go
+++ b/test_suites/metadata/metadata_test.go
@@ -59,7 +59,7 @@ func TestMetaDataResponseHeaders(t *testing.T) {
 	for key, values := range headers {
 		if key != "Metadata-Flavor" {
 			for _, v := range values {
-				if strings.Contains(strings.ToLower(v), "google") {
+				if strings.Contains(strings.ToLower(v), "google") && !strings.Contains(strings.ToLower(v), "google.com") {
 					t.Fatalf("unexpected Google header (key: %q, value: %q) exists in metadata response", key, v)
 				}
 			}


### PR DESCRIPTION
There are some new headers that contain the CSP url [https://csp.withgoogle.com/csp/httpsserver2](https://csp.withgoogle.com/csp/httpsserver2), which breaks the metadata test.  Fix this by only erroring if google is in the value without google.com.