### PR TITLE
Add option for simultaneous suite builds, adjust outpath for local builds

### DIFF
--- a/local_build.sh
+++ b/local_build.sh
@@ -20,22 +20,33 @@ outpath=.
 suites=*
 # the path to the imagetest folder, default value assumes this script is run from the imagetest folder. If set, the commands cd $imagetestroot/cmd and cd $imagetestroot/test_suites should succeed.
 imagetestroot=.
+# number of suites to build simultaneously
+threads=1
 
-
-while getopts "o:s:i:" arg; do
-  case $arg in 
-    o) outpath=$OPTARG;;
+while getopts "o:s:i:j:" arg; do
+  case $arg in
+    o)
+      # Check if the path is absolute (starts with a '/')
+      if [[ "$OPTARG" =~ ^/ ]]; then
+        outpath="$OPTARG"
+      else
+        # If it's a relative path, prepend the current working directory
+        outpath="$(pwd)/$OPTARG"
+      fi
+      ;;
     s) suites=$OPTARG;;
     i) imagetestroot=$OPTARG;;
+    j) threads=$OPTARG;;
     *) echo "unknown arg"
   esac
-done 
+done
 
 
 export CGO_ENABLED=0
-echo "outspath is $outpath"
+echo "outpath is $outpath"
 echo "suites being built are $suites"
 echo "imagetestroot is $imagetestroot"
+echo "building $threads suite(s) simultaneously"
 
 cd $imagetestroot
 go mod download
@@ -47,18 +58,36 @@ go build -o $outpath/manager ./cmd/manager/main.go || exit 1
 
 
 cd test_suites
+JOBS=()     # Array to track PIDs of build jobs
+
 for suite in $suites; do
   [[ -d $suite ]] || continue
-  cd $suite
-  echo "building suite $suite"
-  go test -c -tags cit || exit 1
-  ./"${suite}.test" -test.list '.*' > $outpath/"${suite}_tests.txt" || exit 1
-  mv "${suite}.test" $outpath/"${suite}.amd64.test" || exit 1
-  GOARCH=arm64 go test -c -tags cit || exit 1
-  mv "${suite}.test" "$outpath/${suite}.arm64.test" || exit 1
-  GOOS=windows GOARCH=amd64 go test -c -tags cit || exit 1
-  if [ -f "${suite}.test.exe" ]; then mv "${suite}.test.exe" "$outpath/${suite}64.exe" || exit 1; fi;
-  GOOS=windows GOARCH=386 go test -c -tags cit || exit 1
-  if [ -f "${suite}.test.exe" ]; then mv "${suite}.test.exe" "$outpath/${suite}32.exe" || exit 1; fi;
-  cd ..
+  (
+    cd $suite
+    echo "building suite $suite"
+    go test -c -tags cit || exit 1
+    ./"${suite}.test" -test.list '.*' > $outpath/"${suite}_tests.txt" || exit 1
+    mv "${suite}.test" $outpath/"${suite}.amd64.test" || exit 1
+    GOARCH=arm64 go test -c -tags cit || exit 1
+    mv "${suite}.test" "$outpath/${suite}.arm64.test" || exit 1
+    GOOS=windows GOARCH=amd64 go test -c -tags cit || exit 1
+    if [ -f "${suite}.test.exe" ]; then mv "${suite}.test.exe" "$outpath/${suite}64.exe" || exit 1; fi;
+    GOOS=windows GOARCH=386 go test -c -tags cit || exit 1
+    if [ -f "${suite}.test.exe" ]; then mv "${suite}.test.exe" "$outpath/${suite}32.exe" || exit 1; fi;
+  ) &
+
+  # Add the PID of the last build job to the array
+  JOBS+=($!)
+
+  # Check if the number of running builds has reached the limit
+  if (( ${#JOBS[@]} >= $threads )); then
+    # Wait for any one of the current builds
+    wait -n
+    # Rebuild the array of active build PIDs
+    JOBS=( $(jobs -p) )
+  fi
 done
+
+# Wait for all builds to complete
+wait
+echo "All selected test suites have been built."


### PR DESCRIPTION
Adds the -j argument to the command line to build multiple suites simultaneously.  The default is 1 so it is in line with previous functionality.

Use absolute paths for outpath to make it more compatible with non-docker uses.  Existing functionality/defaults are maintained when the -o option is not passed.