### PR TITLE
Speed up post-test cleanup: region-scope and gate LB scans

### DIFF
--- a/cleanerupper/cleanerupper.go
+++ b/cleanerupper/cleanerupper.go
@@ -450,16 +450,30 @@ func CleanSnapshots(clients Clients, project string, delete PolicyFunc, dryRun b
 	return deleted, errs
 }
 
-// CleanLoadBalancerResources deletes load balancer backend services and associated URL Maps, forwarding rules, network endpoint groups, and HTTP Proxies indicated by the policy func.
-func CleanLoadBalancerResources(clients Clients, project string, delete PolicyFunc, dryRun bool) ([]string, []error) {
+// CleanLoadBalancerResources deletes load balancer backend services and
+// associated URL Maps, forwarding rules, network endpoint groups, and HTTP
+// Proxies indicated by the policy func.
+//
+// regions optionally restricts the scan to the named regions (short names like
+// "us-central1", not URLs). When empty or nil, every region in the project is
+// scanned via ListRegions — slow but exhaustive. Pass the regions a caller
+// expects its resources to live in to avoid ~5 list calls per unused region.
+func CleanLoadBalancerResources(clients Clients, project string, delete PolicyFunc, regions []string, dryRun bool) ([]string, []error) {
 	globalForwardingRules, err := clients.Daisy.AggregatedListForwardingRules(project)
 	if err != nil {
 		return nil, []error{fmt.Errorf("could not list all forwarding rules: %v", err)}
 	}
 
-	regions, err := clients.Daisy.ListRegions(project)
-	if err != nil {
-		return nil, []error{fmt.Errorf("could not list regions: %v", err)}
+	regionNames := regions
+	if len(regionNames) == 0 {
+		computeRegions, err := clients.Daisy.ListRegions(project)
+		if err != nil {
+			return nil, []error{fmt.Errorf("could not list regions: %v", err)}
+		}
+		regionNames = make([]string, 0, len(computeRegions))
+		for _, r := range computeRegions {
+			regionNames = append(regionNames, path.Base(r.SelfLink))
+		}
 	}
 
 	regionalForwardingRules := make(map[string][]*compute.ForwardingRule)
@@ -497,8 +511,7 @@ func CleanLoadBalancerResources(clients Clients, project string, delete PolicyFu
 	}
 	wg.Wait()
 
-	for _, computeRegion := range regions {
-		region := path.Base(computeRegion.SelfLink)
+	for _, region := range regionNames {
 		regionFRs, ok := regionalForwardingRules[region]
 		if !ok {
 			var err error

--- a/cleanerupper/cleanerupper_test.go
+++ b/cleanerupper/cleanerupper_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"path"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -677,7 +678,7 @@ func TestCleanLoadBalancerResources(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			o, errs := CleanLoadBalancerResources(tc.clients, tc.project, tc.policy, tc.dryRun)
+			o, errs := CleanLoadBalancerResources(tc.clients, tc.project, tc.policy, nil, tc.dryRun)
 			if len(errs) > 0 {
 				for _, e := range errs {
 					t.Errorf("error from CleanLoadBalancerResources: %v", e)
@@ -689,6 +690,63 @@ func TestCleanLoadBalancerResources(t *testing.T) {
 				t.Errorf("cmp.Diff(tc.output, o) != nil (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestCleanLoadBalancerResourcesRegionScope verifies that passing a non-empty
+// regions slice skips the ListRegions call entirely and confines the
+// per-region list calls to the named regions.
+func TestCleanLoadBalancerResourcesRegionScope(t *testing.T) {
+	const scopedRegion = "us-central1"
+	var listRegionsCalled, outOfScopeCall string
+	_, daisyFake, err := computeDaisy.NewTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/projects/test-project/aggregated/forwardingRules" {
+			fmt.Fprint(w, `{"items":{}}`)
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/projects/test-project/regions" {
+			// If we reach this, scoping is broken — the function fell back to
+			// ListRegions despite a non-empty scope.
+			listRegionsCalled = r.URL.String()
+			fmt.Fprint(w, `{"items":[]}`)
+			return
+		}
+		// Zonal NEG lookups are scoped per region via a filter; assert that
+		// filter matches the scoped region prefix and return empty.
+		if r.Method == "GET" && r.URL.Path == "/projects/test-project/zones" {
+			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, scopedRegion+"-") {
+				outOfScopeCall = r.URL.String()
+			}
+			fmt.Fprint(w, `{"items":[]}`)
+			return
+		}
+		// Allow region-scoped list endpoints for the scoped region; everything
+		// else is a scope violation.
+		if r.Method == "GET" && strings.HasPrefix(r.URL.Path, fmt.Sprintf("/projects/test-project/regions/%s/", scopedRegion)) {
+			fmt.Fprint(w, `{"items":[]}`)
+			return
+		}
+		if r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/projects/test-project/regions/") {
+			outOfScopeCall = r.URL.String()
+			fmt.Fprint(w, `{"items":[]}`)
+			return
+		}
+		w.WriteHeader(555)
+		fmt.Fprintln(w, "URL and Method not recognized:", r.Method, r.URL)
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, errs := CleanLoadBalancerResources(Clients{Daisy: daisyFake}, "test-project", deleteNothing, []string{scopedRegion}, false); len(errs) > 0 {
+		for _, e := range errs {
+			t.Errorf("CleanLoadBalancerResources: %v", e)
+		}
+	}
+	if listRegionsCalled != "" {
+		t.Errorf("expected ListRegions to be skipped when regions scope is set, but it was called: %s", listRegionsCalled)
+	}
+	if outOfScopeCall != "" {
+		t.Errorf("expected only %q to be scanned, but saw an out-of-scope call: %s", scopedRegion, outOfScopeCall)
 	}
 }
 

--- a/test_suites/loadbalancer/setup.go
+++ b/test_suites/loadbalancer/setup.go
@@ -45,6 +45,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		// Alias IPs are disabled on COS and required for cloud load balancers.
 		return nil
 	}
+	t.CreatesLoadBalancers = true
 	lbnet, err := t.CreateNetwork("loadbalancer", false)
 	if err != nil {
 		return err

--- a/testworkflow.go
+++ b/testworkflow.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"log"
 	"math/rand"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -133,6 +134,13 @@ type TestWorkflow struct {
 	ReservationAffinityBeta *computeBeta.ReservationAffinity
 	// AcceleratorType is the accelerator type to be used for accelerator tests which use GPUs.
 	AcceleratorType string
+	// CreatesLoadBalancers indicates that this test suite creates regional load
+	// balancer resources (forwarding rules, backend services, URL maps, target
+	// HTTP proxies, NEGs, health checks) at runtime. Suites that set this true
+	// opt into the post-test LB cleanup pass; suites that leave it false skip
+	// the call entirely. Default false because only the loadbalancer suite
+	// creates LB resources today.
+	CreatesLoadBalancers bool
 	// argZoneOverride is whether to override the zone from the command line. If
 	// true, the zone from the command line will be enforced if the test suite
 	// does specify a zone. If false, the hardcoded zone will be used.
@@ -1116,20 +1124,80 @@ func cleanTestWorkflow(test *TestWorkflow) (totalCleaned []string, totalErrs []e
 	c := cleanerupper.Clients{Daisy: test.Client}
 	policy := cleanerupper.WorkflowPolicy(test.wf.ID())
 
+	// Scope load-balancer-resource cleanup to the regions this workflow could
+	// have created regional resources in. Scanning every GCP region adds ~200
+	// list calls for no leftover yield in the common single-region case.
+	regions := workflowRegions(test)
+
 	cleaned, errs := cleanerupper.CleanInstances(c, test.wf.Project, policy, false)
 	totalCleaned = append(totalCleaned, cleaned...)
 	totalErrs = append(totalErrs, errs...)
 	cleaned, errs = cleanerupper.CleanDisks(c, test.wf.Project, policy, false)
 	totalCleaned = append(totalCleaned, cleaned...)
 	totalErrs = append(totalErrs, errs...)
-	cleaned, errs = cleanerupper.CleanLoadBalancerResources(c, test.wf.Project, policy, false)
-	totalCleaned = append(totalCleaned, cleaned...)
-	totalErrs = append(totalErrs, errs...)
+	if test.CreatesLoadBalancers {
+		cleaned, errs = cleanerupper.CleanLoadBalancerResources(c, test.wf.Project, policy, regions, false)
+		totalCleaned = append(totalCleaned, cleaned...)
+		totalErrs = append(totalErrs, errs...)
+	}
 	cleaned, errs = cleanerupper.CleanNetworks(c, test.wf.Project, policy, false)
 	totalCleaned = append(totalCleaned, cleaned...)
 	totalErrs = append(totalErrs, errs...)
 
 	return
+}
+
+// regionFromZone returns the region a zone belongs to (e.g. "us-central1" for
+// "us-central1-a"). Returns "" if zone is empty or not in <region>-<suffix>
+// form.
+func regionFromZone(zone string) string {
+	i := strings.LastIndex(zone, "-")
+	if i <= 0 {
+		return ""
+	}
+	return zone[:i]
+}
+
+// workflowRegions returns the sorted unique set of regions this workflow may
+// have created regional resources in. It walks every CreateInstances step
+// (CIT test suites can override the workflow's primary zone on individual
+// VMs, e.g. shapevalidation pinning a shape to europe-west4-a) plus the
+// workflow's zone for VMs that don't set one explicitly. Returns nil if no
+// region can be derived, signalling callers to fall back to scanning all
+// regions.
+//
+// LB resources count as VM-anchored: the loadbalancer suite is the only
+// place CIT creates them, and it derives the region from the in-VM
+// zoneClient.Get lookup. Any test that creates regional resources via a
+// daisy step in a region with no VM (none exist today) would be missed.
+func workflowRegions(test *TestWorkflow) []string {
+	seen := make(map[string]struct{})
+	add := func(zone string) {
+		if r := regionFromZone(zone); r != "" {
+			seen[r] = struct{}{}
+		}
+	}
+	add(test.wf.Zone)
+	for _, step := range test.wf.Steps {
+		if step.CreateInstances == nil {
+			continue
+		}
+		for _, vm := range step.CreateInstances.Instances {
+			add(vm.Zone)
+		}
+		for _, vm := range step.CreateInstances.InstancesBeta {
+			add(vm.Zone)
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	regions := make([]string, 0, len(seen))
+	for r := range seen {
+		regions = append(regions, r)
+	}
+	sort.Strings(regions)
+	return regions
 }
 
 // gets result struct and converts to a jUnit TestSuite

--- a/testworkflow.go
+++ b/testworkflow.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"log"
 	"math/rand"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -1148,9 +1149,13 @@ func cleanTestWorkflow(test *TestWorkflow) (totalCleaned []string, totalErrs []e
 }
 
 // regionFromZone returns the region a zone belongs to (e.g. "us-central1" for
-// "us-central1-a"). Returns "" if zone is empty or not in <region>-<suffix>
-// form.
+// "us-central1-a"). Accepts short names ("us-central1-a") as well as path or
+// URL forms (e.g. "zones/us-central1-a", or a full
+// "https://www.googleapis.com/compute/v1/.../zones/us-central1-a") because
+// daisy may populate vm.Zone with either at different stages. Returns "" if
+// zone is empty or not in <region>-<suffix> form.
 func regionFromZone(zone string) string {
+	zone = path.Base(zone)
 	i := strings.LastIndex(zone, "-")
 	if i <= 0 {
 		return ""

--- a/testworkflow_test.go
+++ b/testworkflow_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 
@@ -127,6 +128,7 @@ func TestAddStopStep(t *testing.T) {
 func TestCleanTestWorkflow(t *testing.T) {
 	twf := NewTestWorkflowForUnitTest("name", "image", "30m")
 	twf.wf.Project = "test-project"
+	twf.CreatesLoadBalancers = true
 	_, daisyFake, err := daisycompute.NewTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "GET" && r.URL.String() == fmt.Sprintf("/projects/%s/aggregated/instances?alt=json&pageToken=&prettyPrint=false", "test-project") {
 			fmt.Fprint(w, `{"Items":{"Instances":{"instances":[{"SelfLink": "projects/test-project/zones/test-zone/instances/test-instance-`+twf.wf.ID()+`", "Zone":"test-zone", "Name": "test-instance-`+twf.wf.ID()+`", "Description": "created by Daisy in workflow \"`+twf.wf.ID()+`\""}]}}}`)
@@ -232,6 +234,136 @@ func TestCleanTestWorkflow(t *testing.T) {
 	cleaned = slices.Compact(cleaned)
 	if diff := cmp.Diff(expect, cleaned); diff != "" {
 		t.Errorf("cmp.Diff(expect, cleaned) != nil (-want +got):\n%s", diff)
+	}
+}
+
+func TestWorkflowRegions(t *testing.T) {
+	testcases := []struct {
+		name     string
+		wfZone   string
+		gaVMs    []string // per-VM zones for the GA (Instance) struct
+		betaVMs  []string // per-VM zones for the Beta (InstanceBeta) struct
+		want     []string
+	}{
+		{
+			name: "no zones at all",
+			want: nil,
+		},
+		{
+			name:   "only workflow zone",
+			wfZone: "us-central1-a",
+			want:   []string{"us-central1"},
+		},
+		{
+			name:    "mixed zones across VM types",
+			wfZone:  "us-central1-a",
+			gaVMs:   []string{"", "europe-west4-a"},
+			betaVMs: []string{"us-east4-b"},
+			want:    []string{"europe-west4", "us-central1", "us-east4"},
+		},
+		{
+			name:   "duplicate zones deduplicated",
+			wfZone: "us-central1-a",
+			gaVMs:  []string{"us-central1-b", "us-central1-c"},
+			want:   []string{"us-central1"},
+		},
+		{
+			name:   "malformed zone ignored",
+			wfZone: "us-central1-a",
+			gaVMs:  []string{"nodash", ""},
+			want:   []string{"us-central1"},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			twf := NewTestWorkflowForUnitTest("name", "image", "30m")
+			twf.wf.Zone = tc.wfZone
+			if len(tc.gaVMs) > 0 {
+				step, err := twf.wf.NewStep("create-vms")
+				if err != nil {
+					t.Fatal(err)
+				}
+				step.CreateInstances = &daisy.CreateInstances{}
+				for i, z := range tc.gaVMs {
+					step.CreateInstances.Instances = append(step.CreateInstances.Instances, &daisy.Instance{
+						Instance: compute.Instance{Name: fmt.Sprintf("ga-%d", i), Zone: z},
+					})
+				}
+			}
+			if len(tc.betaVMs) > 0 {
+				step, err := twf.wf.NewStep("create-vms-beta")
+				if err != nil {
+					t.Fatal(err)
+				}
+				step.CreateInstances = &daisy.CreateInstances{}
+				for i, z := range tc.betaVMs {
+					step.CreateInstances.InstancesBeta = append(step.CreateInstances.InstancesBeta, &daisy.InstanceBeta{
+						Instance: computeBeta.Instance{Name: fmt.Sprintf("beta-%d", i), Zone: z},
+					})
+				}
+			}
+			got := workflowRegions(twf)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("workflowRegions mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestCleanTestWorkflowSkipsLBWhenNotMarked verifies that cleanTestWorkflow
+// makes no requests to load-balancer endpoints when the workflow doesn't set
+// CreatesLoadBalancers.
+func TestCleanTestWorkflowSkipsLBWhenNotMarked(t *testing.T) {
+	twf := NewTestWorkflowForUnitTest("name", "image", "30m")
+	twf.wf.Project = "test-project"
+	twf.wf.Zone = "us-central1-a"
+	var lbCall string
+	_, daisyFake, err := daisycompute.NewTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Any request that touches LB endpoints is a regression — flag and
+		// answer with a 555 so the call surfaces as an error too.
+		if strings.Contains(r.URL.Path, "forwardingRules") ||
+			strings.Contains(r.URL.Path, "backendServices") ||
+			strings.Contains(r.URL.Path, "targetHttpProxies") ||
+			strings.Contains(r.URL.Path, "urlMaps") ||
+			strings.Contains(r.URL.Path, "networkEndpointGroups") ||
+			strings.Contains(r.URL.Path, "healthChecks") {
+			lbCall = r.URL.String()
+			w.WriteHeader(555)
+			return
+		}
+		// Empty responses for the other Clean* phases (instances, disks,
+		// networks, firewalls, subnetworks, routes).
+		switch {
+		case r.URL.Path == "/projects/test-project/aggregated/instances":
+			fmt.Fprint(w, `{"Items":{}}`)
+		case r.URL.Path == "/projects/test-project/aggregated/disks":
+			fmt.Fprint(w, `{"items":{}}`)
+		case r.URL.Path == "/projects/test-project/global/networks":
+			fmt.Fprint(w, `{"items":[]}`)
+		case r.URL.Path == "/projects/test-project/global/firewalls":
+			fmt.Fprint(w, `{"items":[]}`)
+		case r.URL.Path == "/projects/test-project/aggregated/subnetworks":
+			fmt.Fprint(w, `{"items":{}}`)
+		case r.URL.Path == "/projects/test-project/global/routes":
+			fmt.Fprint(w, `{"items":[]}`)
+		default:
+			w.WriteHeader(555)
+			fmt.Fprintln(w, "URL and Method not recognized:", r.Method, r.URL)
+		}
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	twf.Client = daisyFake
+	if twf.CreatesLoadBalancers {
+		t.Fatalf("CreatesLoadBalancers default must be false; got true")
+	}
+	_, errs := cleanTestWorkflow(twf)
+	for _, err := range errs {
+		t.Errorf("cleanTestWorkflow returned error: %v", err)
+	}
+	if lbCall != "" {
+		t.Errorf("expected no LB endpoint requests, but got: %s", lbCall)
 	}
 }
 

--- a/testworkflow_test.go
+++ b/testworkflow_test.go
@@ -239,11 +239,11 @@ func TestCleanTestWorkflow(t *testing.T) {
 
 func TestWorkflowRegions(t *testing.T) {
 	testcases := []struct {
-		name     string
-		wfZone   string
-		gaVMs    []string // per-VM zones for the GA (Instance) struct
-		betaVMs  []string // per-VM zones for the Beta (InstanceBeta) struct
-		want     []string
+		name    string
+		wfZone  string
+		gaVMs   []string // per-VM zones for the GA (Instance) struct
+		betaVMs []string // per-VM zones for the Beta (InstanceBeta) struct
+		want    []string
 	}{
 		{
 			name: "no zones at all",

--- a/testworkflow_test.go
+++ b/testworkflow_test.go
@@ -268,6 +268,13 @@ func TestWorkflowRegions(t *testing.T) {
 			want:   []string{"us-central1"},
 		},
 		{
+			name:    "url-form vm zone reduced to region",
+			wfZone:  "us-central1-a",
+			gaVMs:   []string{"https://www.googleapis.com/compute/v1/projects/p/zones/us-west1-a"},
+			betaVMs: []string{"zones/europe-west4-b"},
+			want:    []string{"europe-west4", "us-central1", "us-west1"},
+		},
+		{
 			name:   "malformed zone ignored",
 			wfZone: "us-central1-a",
 			gaVMs:  []string{"nodash", ""},


### PR DESCRIPTION
Speeds up CIT's per-test cleanup phase by ~98% in typical single-region runs.

- `cleanerupper.CleanLoadBalancerResources` now takes an optional `regions []string` parameter; when set, it iterates only those regions instead of every GCP region returned by `ListRegions` (~40+).
- A new `workflowRegions` helper derives the relevant regions from the workflow's primary zone plus per-VM zone overrides (so suites like `shapevalidation` that pin VMs to `europe-west4-a` are still covered correctly).
- A new opt-in `TestWorkflow.CreatesLoadBalancers` field gates the LB cleanup call entirely. Only `loadbalancer.TestSetup` sets it true; every other suite skips the call since they never create LB resources at runtime (verified by grep — only `test_suites/loadbalancer/loadbalancer_test.go` ever calls `compute.NewForwardingRulesRESTClient`, `InsertBackendService`, etc.).

The pre-existing failure modes (zombie VMs, networks, disks) are still covered — those cleanups are unchanged. Only the LB-resource scan is scoped/gated.

## Problem

CIT's post-test cleanup is a backup for daisy's own teardown hooks. `CleanLoadBalancerResources` walks every GCP region listing forwarding rules, backend services, URL maps, target HTTP proxies, NEGs and health checks. Each region is ~5 list calls; ~40 regions adds up to ~200 calls per test. On a single-region test that's all wasted work, since regional resources only exist where VMs are.

Compounding that: only the `loadbalancer` suite actually creates LB resources. The other ~30 suites were paying for the scan to find nothing.

## Changes

| File | Change |
|---|---|
| `cleanerupper/cleanerupper.go` | `CleanLoadBalancerResources` adds `regions []string` param; nil = scan all (unchanged), non-empty = only those |
| `cleanerupper/cleanerupper_test.go` | Existing call site updated to `nil`; new `TestCleanLoadBalancerResourcesRegionScope` asserts `ListRegions` is skipped and no out-of-scope region is hit when a scope is set |
| `testworkflow.go` | New `CreatesLoadBalancers bool` on `TestWorkflow`; `regionFromZone` and `workflowRegions` helpers; `cleanTestWorkflow` derives `regions` and gates the LB cleanup call on the flag |
| `testworkflow_test.go` | New `TestWorkflowRegions` (table-driven, covers mixed GA/Beta VM zones, dedup, malformed zones); new `TestCleanTestWorkflowSkipsLBWhenNotMarked` (asserts no LB endpoints are hit when the flag is false) |
| `test_suites/loadbalancer/setup.go` | Sets `t.CreatesLoadBalancers = true` after the COS skip |

## Benchmark results

Test setup: `almalinux-9-v20260501` in `us-central1-a`, project `almalinux-image-testing-469421`.

### Per-test cleanup duration

| Test | Before (all-regions, unconditional LB) | After (region-scoped + LB gated) | Speedup |
|---|---|---|---|
| `hostnamevalidation` | 3m49.3s | **2.15s** | ~107× |
| `imageboot` | 4m31.1s | **3.24s** | ~84× |
| `packagevalidation` | 3m56.4s | **4.41s** | ~54× |
| `ssh` | 3m44.8s | **2.21s** | ~101× |
| `loadbalancer` | 3m42.6s | **5.55s** | ~40× (still does LB cleanup, but in 1 region) |

### Wall-clock per scenario (parallel)

| Scenario | Before | After | Savings |
|---|---|---|---|
| 2 tests, `-parallel_count=2` | 7m02s | **3m17s** | 3m45s (~53%) |
| 5 tests, `-parallel_count=5` | 12m20s | **9m37s** | 2m43s (~22%) |

The 5-test wall-clock savings are smaller in proportion because the slowest test (`loadbalancer` at ~9 min of test execution) dominates wall clock — and that test still does the LB cleanup (correctly).

## Why this matters more at low parallelism

Cleanup phases are per-test and run after each test's workflow finishes. When `-parallel_count` is high relative to the number of tests, cleanups overlap with other tests still running — much of the cleanup cost disappears into the wall-clock shadow of the slowest test. When parallelism is **low relative to total tests**, cleanups serialize and every saved second flows directly to wall clock.

Worked example with the measured ~3m45s saved per non-LB test:

| Mode | 40-test run before | 40-test run after | Wall clock saved |
|---|---|---|---|
| `-parallel_count=1` (fully sequential) | 40 × ~3m45s ≈ **2h30m of cleanup** added on top of test time | 40 × ~3s ≈ **2 min of cleanup** | **~2h28m** |
| `-parallel_count=5` (matches our benchmark) | cleanups partially overlap; the slowest test's cleanup is on the critical path | ~5s on the critical path | ~3m on the critical path per "batch" |
| `-parallel_count=40` (one slot per test) | only the slowest test's cleanup blocks the run | ~5s | ~3m42s once |

So **the case that benefits the most is a developer running `-parallel_count=1` to debug or run a representative subset of suites locally**: the cleanup-time savings are linear in test count and fully visible. CI runs with high parallelism still save the same total API calls and project quota, but the wall-clock improvement is bounded by the slowest test on the critical path.