### PR TITLE
Build test_suites concurrently in local_build.sh with a capped pool

### DIFF
--- a/local_build.sh
+++ b/local_build.sh
@@ -13,23 +13,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# usage: local_build.sh -o $outspath -i $imagetestroot -s $suites_to_build
+# usage: local_build.sh -o $outspath -i $imagetestroot -s $suites_to_build -j $jobs
 # the output path of the test files
 outpath=.
 # the suites to build, space separated. all suites are built by default
 suites=*
 # the path to the imagetest folder, default value assumes this script is run from the imagetest folder. If set, the commands cd $imagetestroot/cmd and cd $imagetestroot/test_suites should succeed.
 imagetestroot=.
+# max suites to build concurrently. 0 means auto: max(1, (nproc-1)/3),
+# on the theory that each `go test -c` invocation spawns ~3 hot worker
+# processes (compile, vet, link), so K*3 <= cores-1. Pass -j N to override.
+jobs=0
 
 
-while getopts "o:s:i:" arg; do
-  case $arg in 
+while getopts "o:s:i:j:" arg; do
+  case $arg in
     o) outpath=$OPTARG;;
     s) suites=$OPTARG;;
     i) imagetestroot=$OPTARG;;
+    j) jobs=$OPTARG;;
     *) echo "unknown arg"
   esac
-done 
+done
+
+if [ "$jobs" -eq 0 ]; then
+  jobs=$(( ($(nproc) - 1) / 3 ))
+  [ $jobs -lt 1 ] && jobs=1
+fi
 
 
 export CGO_ENABLED=0
@@ -46,19 +56,58 @@ GOOS=windows GOARCH=386 go build -o $outpath/wrapp32.exe ./cmd/wrapper/main.go |
 go build -o $outpath/manager ./cmd/manager/main.go || exit 1
 
 
-cd test_suites
-for suite in $suites; do
-  [[ -d $suite ]] || continue
-  cd $suite
+# Build one suite (all four arch variants). Run in its own subshell so cd
+# stays scoped and so multiple suites can run concurrently.
+build_suite() {
+  local suite=$1
+  local outpath=$2
+  local root=$3
+  cd "$root/test_suites/$suite" || return 1
   echo "building suite $suite"
-  go test -c -tags cit || exit 1
-  ./"${suite}.test" -test.list '.*' > $outpath/"${suite}_tests.txt" || exit 1
-  mv "${suite}.test" $outpath/"${suite}.amd64.test" || exit 1
-  GOARCH=arm64 go test -c -tags cit || exit 1
-  mv "${suite}.test" "$outpath/${suite}.arm64.test" || exit 1
-  GOOS=windows GOARCH=amd64 go test -c -tags cit || exit 1
-  if [ -f "${suite}.test.exe" ]; then mv "${suite}.test.exe" "$outpath/${suite}64.exe" || exit 1; fi;
-  GOOS=windows GOARCH=386 go test -c -tags cit || exit 1
-  if [ -f "${suite}.test.exe" ]; then mv "${suite}.test.exe" "$outpath/${suite}32.exe" || exit 1; fi;
-  cd ..
+  go test -c -tags cit || return 1
+  ./"${suite}.test" -test.list '.*' > "$outpath/${suite}_tests.txt" || return 1
+  mv "${suite}.test" "$outpath/${suite}.amd64.test" || return 1
+  GOARCH=arm64 go test -c -tags cit || return 1
+  mv "${suite}.test" "$outpath/${suite}.arm64.test" || return 1
+  GOOS=windows GOARCH=amd64 go test -c -tags cit || return 1
+  if [ -f "${suite}.test.exe" ]; then mv "${suite}.test.exe" "$outpath/${suite}64.exe" || return 1; fi
+  GOOS=windows GOARCH=386 go test -c -tags cit || return 1
+  if [ -f "${suite}.test.exe" ]; then mv "${suite}.test.exe" "$outpath/${suite}32.exe" || return 1; fi
+}
+
+abs_outpath=$(cd "$outpath" && pwd)
+abs_root=$(cd "$imagetestroot" && pwd)
+
+# FIFO semaphore: $jobs slots in a named pipe. Each suite reads a token
+# before starting and writes one back when done.
+slotfifo=$(mktemp -u)
+mkfifo "$slotfifo"
+exec 9<>"$slotfifo"
+rm "$slotfifo"
+for i in $(seq 1 $jobs); do echo >&9; done
+
+cd "$abs_root/test_suites"
+pids=()
+names=()
+for suite in $suites; do
+  [[ -d "$suite" ]] || continue
+  read -u 9 # wait for a slot
+  (
+    build_suite "$suite" "$abs_outpath" "$abs_root"
+    rc=$?
+    echo >&9 # release slot regardless of outcome
+    exit $rc
+  ) &
+  pids+=($!)
+  names+=("$suite")
 done
+
+fail=0
+for i in "${!pids[@]}"; do
+  if ! wait "${pids[$i]}"; then
+    echo "[!] suite ${names[$i]} failed"
+    fail=1
+  fi
+done
+exec 9>&-
+[[ $fail -eq 0 ]] || exit 1


### PR DESCRIPTION
Supersedes https://github.com/GoogleCloudPlatform/cloud-image-tests/pull/337

## Summary

Parallelizes the test-suite builds in `local_build.sh` with a self-tuning
concurrency cap. Cold full-suite builds drop from ~5m29s to ~2m30s on a
32-core host — a 54% wall-clock reduction — with safe self-throttling on
smaller hardware.

## Problem

`local_build.sh` builds 41 test suites × 4 GOOS/GOARCH variants each in a
single serial loop. On a 32-core/124-GiB host the average CPU usage during
a build is ~4 cores out of 32 — most of the machine sits idle. Locally
this is just slow; in CI it directly blocks every presubmit job that
rebuilds the test binaries.

Naively parallelizing (launch all 41 suites concurrently) is _slower_ than
it should be: 41 simultaneous `go test -c` invocations race to compile the
same shared dependencies (the imagetest framework, `compute-daisy`, the
GCE compute APIs, stdlib). Go's build cache is filesystem-locked so the
work is safe, but only one winner gets cached per package; the other
~40 simultaneous compiles of the same dep are pure waste. Measured: user
CPU climbs to ~6000s with only a modest wall-clock improvement (4m36s),
and on memory-constrained hosts the process tree can OOM.

## Changes

- New `-j N` flag on `local_build.sh`. `-j 0` (default) means *auto*:
  `max(1, (nproc-1)/3)`. The `(nproc-1)/3` formula matches the
  observation that each `go test -c` spawns ~3 hot worker processes
  (compile, vet, link), so a cap of `K*3 ≤ cores-1` keeps the worker
  count close to the core count without leaving the system starved.
- A FIFO-based semaphore throttles the per-suite background subshells to
  `$jobs` concurrent suites. Each suite still builds its 4 arch variants
  serially inside its slot, so a hung suite can't starve more than one
  slot.
- The per-suite build commands are hoisted into a `build_suite()`
  function — same commands, same outputs, just callable.
- Failure tracking: per-suite exit codes are collected; on any failure
  the script reports which suite(s) failed and exits non-zero.

## Benchmark

Cold cache, 41 suites × 4 archs = 164 build outputs. Single trial each on
a 32-core / 124 GiB host. All runs produce identical 210 artifacts.

| Variant                       | Wall clock | User CPU | Effective cores | Notes |
|-------------------------------|------------|----------|-----------------|-------|
| Serial (today)                | 5m29s      | 1180s    | ~4.3            | baseline |
| Parallel unlimited (41 jobs)  | 4m36s      | 5947s    | ~25             | heavy dup compile, OOM risk |
| **Parallel K=10** *(default on 32 cores)* | **2m30s**  | 2601s    | ~20             | **shipped default** |
| Parallel K=16 (cores/2)       | 2m54s      | 3258s    | ~22             | enough oversubscription to lose |

Per-suite walls in the K=10 run are 8–52 seconds: the first wave of
suites starts cold and pays for the shared compile, the rest finish in
seconds against warm cache. User CPU drops 2.3× compared to the
unlimited variant — most of the previously wasted dup-work is gone.

## Behavior on smaller hardware

The formula degrades gracefully:

| Cores | Default `K` |
|-------|-------------|
| 4     | 1 (serial)  |
| 8     | 2           |
| 16    | 5           |
| 32    | 10          |
| 64    | 21          |

`-j N` is honored verbatim for environments that want explicit control
(CI runners with a known core/memory budget). `-j 0` resets to auto.