### PR TITLE
fix: networkProfile field requires a supported URL

### DIFF
--- a/test_suites/acceleratorconfig/setup.go
+++ b/test_suites/acceleratorconfig/setup.go
@@ -76,7 +76,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	mrdma.Name = mrdmaNetName
 	mrdma.Mtu = 8896                        // Max allowed value
 	mrdma.AutoCreateSubnetworks = new(bool) // false
-	mrdma.NetworkProfile = fmt.Sprintf("global/networkProfiles/%s-vpc-roce", testZone)
+	mrdma.NetworkProfile = fmt.Sprintf("projects/%s/global/networkProfiles/%s-vpc-roce", t.Project.Name, testZone)
 	mrdmaNet, err := t.CreateNetworkFromDaisyNetwork(mrdma)
 	if err != nil {
 		return err

--- a/utils/acceleratorutils/acceleratorutils.go
+++ b/utils/acceleratorutils/acceleratorutils.go
@@ -85,7 +85,7 @@ func CreateNetwork(t *imagetest.TestWorkflow) ([]*computeBeta.NetworkInterface, 
 	mrdma.Name = mrdmaNetName
 	mrdma.Mtu = imagetest.JumboFramesMTU
 	mrdma.AutoCreateSubnetworks = new(bool) // false
-	mrdma.NetworkProfile = fmt.Sprintf("global/networkProfiles/%s-vpc-roce", testZone)
+	mrdma.NetworkProfile = fmt.Sprintf("projects/%s/global/networkProfiles/%s-vpc-roce", t.Project.Name, testZone)
 	mrdmaNet, err := t.CreateNetworkFromDaisyNetwork(mrdma)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Every accelerator RoCE-RDMA test suite fails during setup at the `create-networks` step. The RoCE network profile is referenced with a project-less partial path (`global/networkProfiles/<zone>-vpc-roce`), which the Compute API rejects with `400 ... The URL is malformed`. The `networkProfile` field requires a full URL or a `projects/{projectId}/...`-qualified partial URL.