### PR TITLE
fix: consolidate custom network interface when nic type is preconfigured

### DIFF
--- a/fixtures.go
+++ b/fixtures.go
@@ -880,6 +880,9 @@ func (t *TestVM) AddCustomNetworkWithStackType(network *Network, subnetwork *Sub
 		}
 		if t.instance.NetworkInterfaces == nil {
 			t.instance.NetworkInterfaces = []*compute.NetworkInterface{&networkInterface}
+		} else if len(t.instance.NetworkInterfaces) == 1 && t.instance.NetworkInterfaces[0].Network == "" {
+			networkInterface.NicType = t.instance.NetworkInterfaces[0].NicType
+			t.instance.NetworkInterfaces[0] = &networkInterface
 		} else {
 			t.instance.NetworkInterfaces = append(t.instance.NetworkInterfaces, &networkInterface)
 		}
@@ -893,6 +896,9 @@ func (t *TestVM) AddCustomNetworkWithStackType(network *Network, subnetwork *Sub
 		}
 		if t.instancebeta.NetworkInterfaces == nil {
 			t.instancebeta.NetworkInterfaces = []*computeBeta.NetworkInterface{&networkInterface}
+		} else if len(t.instancebeta.NetworkInterfaces) == 1 && t.instancebeta.NetworkInterfaces[0].Network == "" {
+			networkInterface.NicType = t.instancebeta.NetworkInterfaces[0].NicType
+			t.instancebeta.NetworkInterfaces[0] = &networkInterface
 		} else {
 			t.instancebeta.NetworkInterfaces = append(t.instancebeta.NetworkInterfaces, &networkInterface)
 		}

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -1026,3 +1026,75 @@ func TestMachineMaintenancePolicy(t *testing.T) {
 		})
 	}
 }
+
+func TestAddCustomNetworkGVNICConsolidation(t *testing.T) {
+	twf := NewTestWorkflowForUnitTest("name", "image", "30m")
+	net, err := twf.CreateNetwork("custom-net", false)
+	if err != nil {
+		t.Fatalf("failed to create network: %v", err)
+	}
+	subnet, err := net.CreateSubnetwork("custom-subnet", "10.0.0.0/24")
+	if err != nil {
+		t.Fatalf("failed to create subnetwork: %v", err)
+	}
+
+	// Case 1: UseGVNIC then AddCustomNetwork on standard instance
+	tvm1, err := twf.CreateTestVM("vm1")
+	if err != nil {
+		t.Fatalf("failed to create test vm: %v", err)
+	}
+	tvm1.UseGVNIC()
+	if err := tvm1.AddCustomNetwork(net, subnet); err != nil {
+		t.Fatalf("failed to add custom network: %v", err)
+	}
+	if len(tvm1.instance.NetworkInterfaces) != 1 {
+		t.Errorf("expected 1 network interface after UseGVNIC + AddCustomNetwork, got %d", len(tvm1.instance.NetworkInterfaces))
+	}
+	if tvm1.instance.NetworkInterfaces[0].NicType != "GVNIC" {
+		t.Errorf("expected NicType GVNIC, got %q", tvm1.instance.NetworkInterfaces[0].NicType)
+	}
+	if tvm1.instance.NetworkInterfaces[0].Network != "custom-net" {
+		t.Errorf("expected Network custom-net, got %q", tvm1.instance.NetworkInterfaces[0].Network)
+	}
+	if tvm1.instance.NetworkInterfaces[0].Subnetwork != "custom-subnet" {
+		t.Errorf("expected Subnetwork custom-subnet, got %q", tvm1.instance.NetworkInterfaces[0].Subnetwork)
+	}
+
+	// Case 2: AddCustomNetwork then UseGVNIC on standard instance
+	tvm2, err := twf.CreateTestVM("vm2")
+	if err != nil {
+		t.Fatalf("failed to create test vm: %v", err)
+	}
+	if err := tvm2.AddCustomNetwork(net, subnet); err != nil {
+		t.Fatalf("failed to add custom network: %v", err)
+	}
+	tvm2.UseGVNIC()
+	if len(tvm2.instance.NetworkInterfaces) != 1 {
+		t.Errorf("expected 1 network interface after AddCustomNetwork + UseGVNIC, got %d", len(tvm2.instance.NetworkInterfaces))
+	}
+	if tvm2.instance.NetworkInterfaces[0].NicType != "GVNIC" {
+		t.Errorf("expected NicType GVNIC, got %q", tvm2.instance.NetworkInterfaces[0].NicType)
+	}
+	if tvm2.instance.NetworkInterfaces[0].Network != "custom-net" {
+		t.Errorf("expected Network custom-net, got %q", tvm2.instance.NetworkInterfaces[0].Network)
+	}
+
+	// Case 3: UseGVNIC then AddCustomNetwork on beta instance
+	tvmBeta, err := twf.CreateTestVMBeta("vmbeta")
+	if err != nil {
+		t.Fatalf("failed to create test vm beta: %v", err)
+	}
+	tvmBeta.UseGVNIC()
+	if err := tvmBeta.AddCustomNetwork(net, subnet); err != nil {
+		t.Fatalf("failed to add custom network to beta vm: %v", err)
+	}
+	if len(tvmBeta.instancebeta.NetworkInterfaces) != 1 {
+		t.Errorf("expected 1 network interface on beta vm, got %d", len(tvmBeta.instancebeta.NetworkInterfaces))
+	}
+	if tvmBeta.instancebeta.NetworkInterfaces[0].NicType != "GVNIC" {
+		t.Errorf("expected NicType GVNIC on beta vm, got %q", tvmBeta.instancebeta.NetworkInterfaces[0].NicType)
+	}
+	if tvmBeta.instancebeta.NetworkInterfaces[0].Network != "custom-net" {
+		t.Errorf("expected Network custom-net on beta vm, got %q", tvmBeta.instancebeta.NetworkInterfaces[0].Network)
+	}
+}


### PR DESCRIPTION
Fixes #500

**What was wrong**
When `TestVM.UseGVNIC()` was called prior to `TestVM.AddCustomNetwork()`, `UseGVNIC()` initialized `NetworkInterfaces` with a single entry containing `NicType: "GVNIC"` and an empty `Network` field. Subsequent calls to `AddCustomNetworkWithStackType()` appended a second network interface rather than configuring the primary NIC. This caused test VMs to spin up with two network interfaces (where NIC 0 defaulted to the default VPC network and NIC 1 had the custom network), leading to failures in environments without a default VPC.

**What changed**
- Updated `AddCustomNetworkWithStackType` in `fixtures.go` for both `instance` and `instancebeta` to inspect existing network interfaces. If a single preconfigured NIC without an assigned network exists (such as from a prior `UseGVNIC()` call), it updates the primary interface with the custom network and preserves the preconfigured `NicType`.
- Added unit test `TestAddCustomNetworkGVNICConsolidation` in `fixtures_test.go` covering `UseGVNIC()` followed by `AddCustomNetwork()`, `AddCustomNetwork()` followed by `UseGVNIC()`, and beta instance consolidation.

**Verification**
- `go test -v -run TestAddCustomNetworkGVNICConsolidation .` -> PASS
- `go test . ./cleanerupper/... ./utils/...` -> all unit tests PASS
- `gofmt -d fixtures.go fixtures_test.go` -> clean formatting