### PR TITLE
feat(pluginmanager): Start running the core-plugin tests on Ubuntu 26.10

### DIFF
--- a/test_suites/pluginmanager/setup.go
+++ b/test_suites/pluginmanager/setup.go
@@ -33,7 +33,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	}
 	defaultVM.RunTests("TestPluginCleanup")
 
-	if !strings.Contains(t.Image.Name, "guest-agent") && (strings.Contains(t.Image.Name, "sles") || strings.Contains(t.Image.Name, "ubuntu")) {
+	if !strings.Contains(t.Image.Name, "guest-agent") && (strings.Contains(t.Image.Name, "sles") || (strings.Contains(t.Image.Name, "ubuntu") && !strings.Contains(t.Image.Name, "-2610-"))) {
 		noCorePluginVM, err := t.CreateTestVM("nocoreplugin")
 		if err != nil {
 			return err


### PR DESCRIPTION
Ubuntu Stonking Stingray 26.10 now ships with the new `core-plugin` `google-guest-agent` pkg, therefore those images should start running the core-plugin tests (`TestLocalPlugin`, `TestCorePluginStop`, `TestACSDisabled`) rather than the old `TestPluginManagerNoCorePlugin` test.

This commit excludes Ubuntu `-2610-` image names from the no-core-plugin branch so they start taking the core-plugin path instead (earlier Ubuntu image releases will continue running TestPluginManagerNoCorePlugin for now until the pkg goes through SRU; I'll update to include the rest of the Ubuntu suites as the SRU/backports progress)